### PR TITLE
Fixes conversion of multi-file CDRWin images

### DIFF
--- a/Aaru.Images/CDRWin/Read.cs
+++ b/Aaru.Images/CDRWin/Read.cs
@@ -368,6 +368,7 @@ namespace Aaru.DiscImages
 
                         _discImage.IsRedumpGigadisc = true;
                         currentSession              = 2;
+                        firstTrackInSession         = true;
                     }
                     else if(matchLba.Success)
                         AaruConsole.DebugWriteLine("CDRWin plugin", "Found REM MSF at line {0}", lineNumber);
@@ -1175,6 +1176,10 @@ namespace Aaru.DiscImages
 
                     if(_discImage.Tracks[i].Indexes.TryGetValue(0, out int idx0))
                         _offsetMap.Add(_discImage.Tracks[i].Sequence, (ulong)idx0 + previousPartitionsSize);
+                    else if(_discImage.IsRedumpGigadisc && _discImage.Tracks[i].Sequence == 3) {
+                        _offsetMap.Add(_discImage.Tracks[i].Sequence, gdRomSession2Offset);
+                        previousPartitionsSize = gdRomSession2Offset;
+                    }
                     else if(_discImage.Tracks[i].Sequence > 1)
                         _offsetMap.Add(_discImage.Tracks[i].Sequence,
                                        (ulong)(_discImage.Tracks[i].Indexes[1] - _discImage.Tracks[i].Pregap) + 

--- a/Aaru.Images/CDRWin/Read.cs
+++ b/Aaru.Images/CDRWin/Read.cs
@@ -1140,6 +1140,8 @@ namespace Aaru.DiscImages
                 Partitions = new List<Partition>();
 
                 ulong partitionSequence = 0;
+                ulong previousPartitionsSize = 0;
+                string previousFile = _discImage.Tracks[0].TrackFile.DataFilter.GetBasePath();
 
                 _offsetMap = new Dictionary<uint, ulong>();
 
@@ -1165,15 +1167,22 @@ namespace Aaru.DiscImages
                     partition.Type        = _discImage.Tracks[i].TrackType;
 
                     partitionSequence++;
+                    
+                    if(_discImage.Tracks[i].TrackFile.DataFilter.GetBasePath() != previousFile){
+                        previousPartitionsSize += _discImage.Tracks[i - 1].Sectors;
+                        previousFile            = _discImage.Tracks[i].TrackFile.DataFilter.GetBasePath();
+                    }
 
                     if(_discImage.Tracks[i].Indexes.TryGetValue(0, out int idx0))
-                        _offsetMap.Add(_discImage.Tracks[i].Sequence, (ulong)idx0);
+                        _offsetMap.Add(_discImage.Tracks[i].Sequence, (ulong)idx0 + previousPartitionsSize);
                     else if(_discImage.Tracks[i].Sequence > 1)
                         _offsetMap.Add(_discImage.Tracks[i].Sequence,
-                                       (ulong)(_discImage.Tracks[i].Indexes[1] - _discImage.Tracks[i].Pregap));
+                                       (ulong)(_discImage.Tracks[i].Indexes[1] - _discImage.Tracks[i].Pregap) + 
+                                       previousPartitionsSize);
                     else
-                        _offsetMap.Add(_discImage.Tracks[i].Sequence, (ulong)_discImage.Tracks[i].Indexes[1]);
-
+                        _offsetMap.Add(_discImage.Tracks[i].Sequence, (ulong)_discImage.Tracks[i].Indexes[1] + 
+                                                                      previousPartitionsSize);
+                    
                     Partitions.Add(partition);
                 }
 


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] I have read the **CONTRIBUTING** document.
- [X] My code follows the code style of this project.

Fixes conversion of multi-file CDRWin images.

Redump GD-ROM still crashes but now do so at 99.99% converted. 