### PR TITLE
Add DiskDupe (DDI) image format

### DIFF
--- a/Aaru.Images/Aaru.Images.csproj
+++ b/Aaru.Images/Aaru.Images.csproj
@@ -250,6 +250,14 @@
     <Compile Include="DiskCopy42\Unsupported.cs" />
     <Compile Include="DiskCopy42\Verify.cs" />
     <Compile Include="DiskCopy42\Write.cs" />
+    <Compile Include="DiskDupe\Constants.cs" />
+    <Compile Include="DiskDupe\DiskDupe.cs" />
+    <Compile Include="DiskDupe\Helpers.cs" />
+    <Compile Include="DiskDupe\Identify.cs" />
+    <Compile Include="DiskDupe\Properties.cs" />
+    <Compile Include="DiskDupe\Read.cs" />
+    <Compile Include="DiskDupe\Structs.cs" />
+    <Compile Include="DiskDupe\Unsupported.cs" />
     <Compile Include="DriDiskCopy\Constants.cs" />
     <Compile Include="DriDiskCopy\Enums.cs" />
     <Compile Include="DriDiskCopy\Identify.cs" />

--- a/Aaru.Images/DiskDupe/Constants.cs
+++ b/Aaru.Images/DiskDupe/Constants.cs
@@ -1,0 +1,47 @@
+﻿// /***************************************************************************
+// Aaru Data Preservation Suite
+// ----------------------------------------------------------------------------
+//
+// Filename       : Constants.cs
+// Author(s)      : Michael Drüing <michael@drueing.de>
+//
+// Component      : Disk image plugins.
+//
+// --[ Description ] ----------------------------------------------------------
+//
+//     Contains constants for DiskDupe DDI disk images.
+//
+// --[ License ] --------------------------------------------------------------
+//
+//     This library is free software; you can redistribute it and/or modify
+//     it under the terms of the GNU Lesser General Public License as
+//     published by the Free Software Foundation; either version 2.1 of the
+//     License, or (at your option) any later version.
+//
+//     This library is distributed in the hope that it will be useful, but
+//     WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//     Lesser General Public License for more details.
+//
+//     You should have received a copy of the GNU Lesser General Public
+//     License along with this library; if not, see <http://www.gnu.org/licenses/>.
+//
+// ----------------------------------------------------------------------------
+// Copyright © 2021 Michael Drüing
+// Copyright © 2011-2021 Natalia Portillo
+// ****************************************************************************/
+
+namespace Aaru.DiscImages
+{
+    public sealed partial class DiskDupe
+    {
+        /// <summary>Start of data sectors in disk image, should be 0x100</summary>
+        const uint TRACKMAP_OFFSET = 100;
+
+        /// <summary>The header identification string</summary>
+        readonly byte[] _headerMagic =
+        {
+            0x49, 0x4d, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+        };
+    }
+}

--- a/Aaru.Images/DiskDupe/DiskDupe.cs
+++ b/Aaru.Images/DiskDupe/DiskDupe.cs
@@ -1,0 +1,112 @@
+// /***************************************************************************
+// Aaru Data Preservation Suite
+// ----------------------------------------------------------------------------
+//
+// Filename       : DiskDupe.cs
+// Author(s)      : Michael Drüing <michael@drueing.de>
+//
+// Component      : Disk image plugins.
+//
+// --[ Description ] ----------------------------------------------------------
+//
+//     Manages floppy disk images created with DiskDupe
+//
+// --[ License ] --------------------------------------------------------------
+//
+//     This library is free software; you can redistribute it and/or modify
+//     it under the terms of the GNU Lesser General Public License as
+//     published by the Free Software Foundation; either version 2.1 of the
+//     License, or (at your option) any later version.
+//
+//     This library is distributed in the hope that it will be useful, but
+//     WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//     Lesser General Public License for more details.
+//
+//     You should have received a copy of the GNU Lesser General Public
+//     License along with this library; if not, see <http://www.gnu.org/licenses/>.
+//
+// ----------------------------------------------------------------------------
+// Copyright © 2021 Michael Drüing
+// Copyright © 2011-2021 Natalia Portillo
+// ****************************************************************************/
+
+/* Some information on the file format from Michal Necasek (www.os2museum.com):
+ *
+ * The DDI diskette image format was used by the DiskDupe DOS utility,
+ * developed by Micro System Designs, Inc. of Cupertino, California in the
+ * early 1990. DiskDupe was used to drive floppy autoloaders/duplicators
+ * and disk image functionality was a fringe feature.
+ *
+ * All information about this format was obtained by analyzing available image
+ * files and may not be entirely accurate.
+ *
+ * The DDI (DiskDupe Image) format is very simplistic, only supporting
+ * standard PC floppy formats. It was not intended as a generic floppy disk
+ * archival format.
+ *
+ * There is no compression and no checksums, but provisions are made to leave
+ * out unused tracks. There is a track map at the beginning of the image.
+ * The image header is the same size as a single track; the track map uses
+ * this fact and gives the starting offset of each track in units of one
+ * track's worth of data (e.g. 7.5KB for 1.2M images).
+ *
+ * There is a unique signature ('IM' followed by several zeroes), which means
+ * that DDI files are easy to recognize.
+ */
+
+using System.Collections.Generic;
+using Aaru.CommonTypes.Enums;
+using Aaru.CommonTypes.Interfaces;
+using Aaru.CommonTypes.Structs;
+
+// ReSharper disable NotAccessedField.Local
+
+namespace Aaru.DiscImages
+{
+    public sealed partial class DiskDupe : IMediaImage
+    {
+        /// <summary>Every track that has been read is cached here</summary>
+        readonly Dictionary<int, byte[]> _trackCache = new Dictionary<int, byte[]>();
+
+        /// <summary>The offset in the file where each track starts, or -1 if the track is not present</summary>
+        readonly Dictionary<int, long> _trackOffset = new Dictionary<int, long>();
+
+        /// <summary>The DDI file header after the image has been opened</summary>
+        FileHeader _fileHeader;
+
+        /// <summary>The track map for the image after it has been opened</summary>
+        TrackInfo[] _trackMap;
+
+        /// <summary>The track offsets in the image after the file has been opened</summary>
+        long[] _trackOffsets;
+
+        /// <summary>The ImageFilter we're reading from, after the file has been opened</summary>
+        IFilter _ddiImageFilter;
+        ImageInfo _imageInfo;
+
+        public DiskDupe() => _imageInfo = new ImageInfo
+        {
+            ReadableSectorTags    = new List<SectorTagType>(),
+            ReadableMediaTags     = new List<MediaTagType>(),
+            HasPartitions         = false,
+            HasSessions           = false,
+            Version               = null,
+            Application           = null,
+            ApplicationVersion    = null,
+            Creator               = null,
+            Comments              = null,
+            MediaManufacturer     = null,
+            MediaModel            = null,
+            MediaSerialNumber     = null,
+            MediaBarcode          = null,
+            MediaPartNumber       = null,
+            MediaSequence         = 0,
+            LastMediaSequence     = 0,
+            DriveManufacturer     = null,
+            DriveModel            = null,
+            DriveSerialNumber     = null,
+            DriveFirmwareRevision = null
+        };
+    }
+}

--- a/Aaru.Images/DiskDupe/Helpers.cs
+++ b/Aaru.Images/DiskDupe/Helpers.cs
@@ -1,0 +1,93 @@
+﻿// /***************************************************************************
+// Aaru Data Preservation Suite
+// ----------------------------------------------------------------------------
+//
+// Filename       : Helpers.cs
+// Author(s)      : Michael Drüing <michael@drueing.de>
+//
+// Component      : Disk image plugins.
+//
+// --[ Description ] ----------------------------------------------------------
+//
+//     Contains helpers for DiskDupe DDI disk images.
+//
+// --[ License ] --------------------------------------------------------------
+//
+//     This library is free software; you can redistribute it and/or modify
+//     it under the terms of the GNU Lesser General Public License as
+//     published by the Free Software Foundation; either version 2.1 of the
+//     License, or (at your option) any later version.
+//
+//     This library is distributed in the hope that it will be useful, but
+//     WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//     Lesser General Public License for more details.
+//
+//     You should have received a copy of the GNU Lesser General Public
+//     License along with this library; if not, see <http://www.gnu.org/licenses/>.
+//
+// ----------------------------------------------------------------------------
+// Copyright © 2021 Michael Drüing
+// Copyright © 2011-2021 Natalia Portillo
+// ****************************************************************************/
+
+using System;
+using System.IO;
+using System.Linq;
+using Aaru.Console;
+using Aaru.Helpers;
+
+namespace Aaru.DiscImages
+{
+    public sealed partial class DiskDupe
+    {
+        bool TryReadHeader(Stream stream, ref FileHeader fhdr, ref TrackInfo[] tmap, ref long[] toffsets)
+        {
+            int numTracks;
+            int trackLen; // the length of a single track, in bytes
+            TrackInfo[] trackMap;
+            byte[] buffer = new byte[6];
+            FileHeader fHeader;
+            long[] trackOffsets;
+
+            stream.Seek(0, SeekOrigin.Begin);
+
+            if(stream.Length < 256)
+                return false;
+
+            // read and check signature
+            fHeader.signature = new byte[10];
+            stream.Read(fHeader.signature, 0, 10);
+            if (!fHeader.signature.SequenceEqual(_headerMagic))
+                return false;
+
+            // read and check disk type byte
+            fHeader.diskType = (byte)stream.ReadByte();
+            if ((fHeader.diskType < 1) || (fHeader.diskType > 4))
+                return false;
+
+            // seek to start of the trackmap
+            stream.Seek(TRACKMAP_OFFSET, SeekOrigin.Begin);
+            numTracks = diskTypes[fHeader.diskType].cyl * diskTypes[fHeader.diskType].hd;
+            trackLen = 512 * diskTypes[fHeader.diskType].spt;
+            trackMap = new TrackInfo[numTracks];
+            trackOffsets = new long[numTracks];
+
+            AaruConsole.DebugWriteLine("DiskDupe plugin", "Identified image with C/H/S = {0}/{1}/{2}", 
+                    diskTypes[fHeader.diskType].cyl, diskTypes[fHeader.diskType].hd, diskTypes[fHeader.diskType].spt);
+
+            // read the trackmap and store the track offsets
+            for (int i = 0; i < numTracks; i++)
+            {
+                stream.Read(buffer, 0, 6);
+                trackMap[i] = Marshal.ByteArrayToStructureBigEndian<TrackInfo>(buffer);
+                trackOffsets[i] = trackLen * trackMap[i].trackNumber;
+            }
+
+            fhdr = fHeader;
+            tmap = trackMap;
+            toffsets = trackOffsets;
+            return true;
+        }
+    }
+}

--- a/Aaru.Images/DiskDupe/Identify.cs
+++ b/Aaru.Images/DiskDupe/Identify.cs
@@ -1,0 +1,54 @@
+﻿// /***************************************************************************
+// Aaru Data Preservation Suite
+// ----------------------------------------------------------------------------
+//
+// Filename       : Identify.cs
+// Author(s)      : Michael Drüing <michael@drueing.de>
+//
+// Component      : Disk image plugins.
+//
+// --[ Description ] ----------------------------------------------------------
+//
+//     Identifies DiskDupe DDI disk images.
+//
+// --[ License ] --------------------------------------------------------------
+//
+//     This library is free software; you can redistribute it and/or modify
+//     it under the terms of the GNU Lesser General Public License as
+//     published by the Free Software Foundation; either version 2.1 of the
+//     License, or (at your option) any later version.
+//
+//     This library is distributed in the hope that it will be useful, but
+//     WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//     Lesser General Public License for more details.
+//
+//     You should have received a copy of the GNU Lesser General Public
+//     License along with this library; if not, see <http://www.gnu.org/licenses/>.
+//
+// ----------------------------------------------------------------------------
+// Copyright © 2021 Michael Drüing
+// Copyright © 2011-2021 Natalia Portillo
+// ****************************************************************************/
+
+using System.IO;
+using Aaru.CommonTypes.Interfaces;
+using Aaru.Helpers;
+
+namespace Aaru.DiscImages
+{
+    public sealed partial class DiskDupe
+    {
+        public bool Identify(IFilter imageFilter)
+        {
+            Stream stream = imageFilter.GetDataForkStream();
+            FileHeader fHeader = new FileHeader();
+            TrackInfo[] trackMap = null;
+            long[] trackOffsets = null;
+
+            // TODO: validate the tracks
+            // For now, having a valid header should be sufficient.
+            return TryReadHeader(stream, ref fHeader, ref trackMap, ref trackOffsets);
+        }
+    }
+}

--- a/Aaru.Images/DiskDupe/Properties.cs
+++ b/Aaru.Images/DiskDupe/Properties.cs
@@ -1,0 +1,59 @@
+﻿// /***************************************************************************
+// Aaru Data Preservation Suite
+// ----------------------------------------------------------------------------
+//
+// Filename       : Properties.cs
+// Author(s)      : Michael Drüing <michael@drueing.de>
+//
+// Component      : Disk image plugins.
+//
+// --[ Description ] ----------------------------------------------------------
+//
+//     Contains properties for DiskDupe DDI disk images.
+//
+// --[ License ] --------------------------------------------------------------
+//
+//     This library is free software; you can redistribute it and/or modify
+//     it under the terms of the GNU Lesser General Public License as
+//     published by the Free Software Foundation; either version 2.1 of the
+//     License, or (at your option) any later version.
+//
+//     This library is distributed in the hope that it will be useful, but
+//     WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//     Lesser General Public License for more details.
+//
+//     You should have received a copy of the GNU Lesser General Public
+//     License along with this library; if not, see <http://www.gnu.org/licenses/>.
+//
+// ----------------------------------------------------------------------------
+// Copyright © 2021 Michael Drüing
+// Copyright © 2011-2021 Natalia Portillo
+// ****************************************************************************/
+
+using System;
+using System.Collections.Generic;
+using Aaru.CommonTypes;
+using Aaru.CommonTypes.Exceptions;
+using Aaru.CommonTypes.Structs;
+using Schemas;
+
+namespace Aaru.DiscImages
+{
+    public sealed partial class DiskDupe
+    {
+        public List<Partition> Partitions =>
+            throw new FeatureUnsupportedImageException("Feature not supported by image format");
+        public List<Track> Tracks =>
+            throw new FeatureUnsupportedImageException("Feature not supported by image format");
+        public List<Session> Sessions =>
+            throw new FeatureUnsupportedImageException("Feature not supported by image format");
+        public string                 Name         => "DiskDupe DDI Disk Image";
+        public Guid                   Id           => new Guid("5439B4A2-5F38-33A7-B8DC-3910D296B3DD");
+        public string                 Author       => "Michael Drüing";
+        public string                 Format       => "DDI disk image";
+        public ImageInfo              Info         => _imageInfo;
+        public List<DumpHardwareType> DumpHardware => null;
+        public CICMMetadataType       CicmMetadata => null;
+    }
+}

--- a/Aaru.Images/DiskDupe/Read.cs
+++ b/Aaru.Images/DiskDupe/Read.cs
@@ -1,0 +1,130 @@
+﻿// /***************************************************************************
+// Aaru Data Preservation Suite
+// ----------------------------------------------------------------------------
+//
+// Filename       : Read.cs
+// Author(s)      : Michael Drüing <michael@drueing.de>
+//
+// Component      : Disk image plugins.
+//
+// --[ Description ] ----------------------------------------------------------
+//
+//     Reads DiskDupe DDI disk images.
+//
+// --[ License ] --------------------------------------------------------------
+//
+//     This library is free software; you can redistribute it and/or modify
+//     it under the terms of the GNU Lesser General Public License as
+//     published by the Free Software Foundation; either version 2.1 of the
+//     License, or (at your option) any later version.
+//
+//     This library is distributed in the hope that it will be useful, but
+//     WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//     Lesser General Public License for more details.
+//
+//     You should have received a copy of the GNU Lesser General Public
+//     License along with this library; if not, see <http://www.gnu.org/licenses/>.
+//
+// ----------------------------------------------------------------------------
+// Copyright © 2021 Michael Drüing
+// Copyright © 2011-2021 Natalia Portillo
+// ****************************************************************************/
+
+using System;
+using System.IO;
+using Aaru.CommonTypes;
+using Aaru.CommonTypes.Enums;
+using Aaru.CommonTypes.Interfaces;
+using Aaru.Console;
+using Aaru.Helpers;
+
+namespace Aaru.DiscImages
+{
+    public sealed partial class DiskDupe
+    {
+        public bool Open(IFilter imageFilter)
+        {
+            Stream stream = imageFilter.GetDataForkStream();
+
+            FileHeader fHeader = new FileHeader();
+            TrackInfo[] trackMap = null;
+            long[] trackOffsets = null;
+
+            if (!TryReadHeader(stream, ref fHeader, ref trackMap, ref trackOffsets))
+            {
+                return false;
+            }
+
+            AaruConsole.DebugWriteLine("DiskDupe Plugin",
+                                       "Detected DiskDupe DDI image with {0} tracks and {1} sectors per track.",
+                                       diskTypes[fHeader.diskType].cyl, diskTypes[fHeader.diskType].spt);
+
+            _imageInfo.Cylinders       = diskTypes[fHeader.diskType].cyl;
+            _imageInfo.Heads           = diskTypes[fHeader.diskType].hd;
+            _imageInfo.SectorsPerTrack = diskTypes[fHeader.diskType].spt;
+            _imageInfo.SectorSize      = 512; // only 512 bytes per sector supported
+            _imageInfo.Sectors         = _imageInfo.Heads * _imageInfo.Cylinders * _imageInfo.SectorsPerTrack;
+            _imageInfo.ImageSize       = _imageInfo.Sectors * _imageInfo.SectorSize;
+
+            _imageInfo.XmlMediaType = XmlMediaType.BlockMedia;
+
+            _imageInfo.CreationTime         = imageFilter.GetCreationTime();
+            _imageInfo.LastModificationTime = imageFilter.GetLastWriteTime();
+            _imageInfo.MediaTitle           = Path.GetFileNameWithoutExtension(imageFilter.GetFilename());
+
+            _imageInfo.MediaType = Geometry.GetMediaType(((ushort)_imageInfo.Cylinders, (byte)_imageInfo.Heads,
+                                                          (ushort)_imageInfo.SectorsPerTrack, 512, MediaEncoding.MFM,
+                                                          false));
+
+
+            // save some variables for later use
+            _fileHeader     = fHeader;
+            _ddiImageFilter = imageFilter;
+            _trackMap       = trackMap;
+            _trackOffsets   = trackOffsets;
+
+            return true;
+        }
+
+        public byte[] ReadSector(ulong sectorAddress)
+        {
+            int trackNum     = (int)(sectorAddress / _imageInfo.SectorsPerTrack);
+            int sectorOffset = (int)(sectorAddress % _imageInfo.SectorsPerTrack);
+
+            if(sectorAddress > _imageInfo.Sectors - 1)
+                throw new ArgumentOutOfRangeException(nameof(sectorAddress), "Sector address not found");
+
+            if(trackNum > 2 * _imageInfo.Cylinders)
+                throw new ArgumentOutOfRangeException(nameof(sectorAddress), "Sector address not found");
+
+            byte[] result = new byte[_imageInfo.SectorSize];
+
+            if(_trackMap[trackNum].present != 1)
+                Array.Clear(result, 0, (int)_imageInfo.SectorSize);
+            else
+            {
+                Stream strm = _ddiImageFilter.GetDataForkStream();
+
+                strm.Seek(_trackOffsets[trackNum] + sectorOffset * _imageInfo.SectorSize, SeekOrigin.Begin);
+
+                strm.Read(result, 0, (int)_imageInfo.SectorSize);
+            }
+
+            return result;
+        }
+
+        public byte[] ReadSectors(ulong sectorAddress, uint count)
+        {
+            byte[] result = new byte[count * _imageInfo.SectorSize];
+
+            if(sectorAddress + count > _imageInfo.Sectors)
+                throw new ArgumentOutOfRangeException(nameof(count), "Requested more sectors than available");
+
+            for(int i = 0; i < count; i++)
+                ReadSector(sectorAddress + (ulong)i).CopyTo(result, i * _imageInfo.SectorSize);
+
+            return result;
+        }
+    }
+}

--- a/Aaru.Images/DiskDupe/Structs.cs
+++ b/Aaru.Images/DiskDupe/Structs.cs
@@ -1,0 +1,78 @@
+﻿// /***************************************************************************
+// Aaru Data Preservation Suite
+// ----------------------------------------------------------------------------
+//
+// Filename       : Structs.cs
+// Author(s)      : Michael Drüing <michael@drueing.de>
+//
+// Component      : Disk image plugins.
+//
+// --[ Description ] ----------------------------------------------------------
+//
+//     Contains structures for DiskDupe DDI disk images.
+//
+// --[ License ] --------------------------------------------------------------
+//
+//     This library is free software; you can redistribute it and/or modify
+//     it under the terms of the GNU Lesser General Public License as
+//     published by the Free Software Foundation; either version 2.1 of the
+//     License, or (at your option) any later version.
+//
+//     This library is distributed in the hope that it will be useful, but
+//     WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//     Lesser General Public License for more details.
+//
+//     You should have received a copy of the GNU Lesser General Public
+//     License along with this library; if not, see <http://www.gnu.org/licenses/>.
+//
+// ----------------------------------------------------------------------------
+// Copyright © 2021 Michael Drüing
+// Copyright © 2011-2021 Natalia Portillo
+// ****************************************************************************/
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+
+namespace Aaru.DiscImages
+{
+    [SuppressMessage("ReSharper", "UnusedType.Local")]
+    public sealed partial class DiskDupe
+    {
+        struct DiskType {
+            public byte cyl;
+            public byte hd;
+            public byte spt;
+        }
+
+        readonly DiskType[] diskTypes = {
+            new DiskType { cyl = 0,  hd = 0, spt = 0  },  // Type 0 - invalid
+            new DiskType { cyl = 40, hd = 2, spt = 9  },  // Type 1 - 360k
+            new DiskType { cyl = 80, hd = 2, spt = 15 },  // Type 2 - 1.2m
+            new DiskType { cyl = 80, hd = 2, spt = 9  },  // Type 3 - 720k
+            new DiskType { cyl = 80, hd = 2, spt = 18 }   // Type 4 - 1.44m
+        };
+
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        struct TrackInfo {
+            public byte present; // 1 = present, 0 = absent
+            public byte trackNumber;
+            public byte zero1;
+            public byte zero2;
+            public byte zero3;
+            public byte unknown; // always 1?
+        }
+
+        /// <summary>The global header of a DDI image file</summary>
+        [StructLayout(LayoutKind.Sequential, Pack = 1)]
+        struct FileHeader
+        {
+            /// <summary>The file signature</summary>
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 10)]
+            public byte[] signature;
+
+            /// <summary>Disk type</summary>
+            public byte diskType;
+        }
+    }
+}

--- a/Aaru.Images/DiskDupe/Unsupported.cs
+++ b/Aaru.Images/DiskDupe/Unsupported.cs
@@ -1,0 +1,56 @@
+﻿// /***************************************************************************
+// Aaru Data Preservation Suite
+// ----------------------------------------------------------------------------
+//
+// Filename       : Unsupported.cs
+// Author(s)      : Michael Drüing <michael@drueing.de>
+//
+// Component      : Disk image plugins.
+//
+// --[ Description ] ----------------------------------------------------------
+//
+//     Contains features unsupported by DiskDupe DDI disk images.
+//
+// --[ License ] --------------------------------------------------------------
+//
+//     This library is free software; you can redistribute it and/or modify
+//     it under the terms of the GNU Lesser General Public License as
+//     published by the Free Software Foundation; either version 2.1 of the
+//     License, or (at your option) any later version.
+//
+//     This library is distributed in the hope that it will be useful, but
+//     WITHOUT ANY WARRANTY; without even the implied warranty of
+//     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//     Lesser General Public License for more details.
+//
+//     You should have received a copy of the GNU Lesser General Public
+//     License along with this library; if not, see <http://www.gnu.org/licenses/>.
+//
+// ----------------------------------------------------------------------------
+// Copyright © 2021 Michael Drüing
+// Copyright © 2011-2021 Natalia Portillo
+// ****************************************************************************/
+
+using Aaru.CommonTypes.Enums;
+using Aaru.CommonTypes.Exceptions;
+
+namespace Aaru.DiscImages
+{
+    public sealed partial class DiskDupe
+    {
+        public byte[] ReadDiskTag(MediaTagType tag) =>
+            throw new FeatureUnsupportedImageException("Feature not supported by image format");
+
+        public byte[] ReadSectorTag(ulong sectorAddress, SectorTagType tag) =>
+            throw new FeatureUnsupportedImageException("Feature not supported by image format");
+
+        public byte[] ReadSectorsTag(ulong sectorAddress, uint length, SectorTagType tag) =>
+            throw new FeatureUnsupportedImageException("Feature not supported by image format");
+
+        public byte[] ReadSectorLong(ulong sectorAddress) =>
+            throw new FeatureUnsupportedImageException("Feature not supported by image format");
+
+        public byte[] ReadSectorsLong(ulong sectorAddress, uint length) =>
+            throw new FeatureUnsupportedImageException("Feature not supported by image format");
+    }
+}


### PR DESCRIPTION
This PR adds support for DiskDupe (DDI) image files. 3 sample files are attached. More are available if required

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New filesystem, test images in [url]
- [x] New media image, test images here: [diskdupe_files.zip](https://github.com/aaru-dps/Aaru/files/6097703/diskdupe_files.zip)
- [ ] New partition scheme, test images in [url]
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.